### PR TITLE
Remove dependency to CGO in statically linked binary

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -2,4 +2,4 @@
 go get -d ./...
 go get -d github.com/inconshreveable/mousetrap
 go get -d github.com/Microsoft/go-winio
-gox -ldflags '-w -s' -output='build/scraper_{{.OS}}_{{.Arch}}'
+CGO_ENABLE=0 gox -ldflags '-w -s' -output='build/scraper_{{.OS}}_{{.Arch}}'


### PR DESCRIPTION
- This makes more compatibility with Alpine Linux.