### PR TITLE
Add project root to test targets

### DIFF
--- a/bin/coverage.sh
+++ b/bin/coverage.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 outdir=$(mktemp -d)
+shopt -s dotglob
 
 for pkg in '' 'scraper' 'commands' ; do
   go test \


### PR DESCRIPTION
- *.out leaks .out file when `shopt -s dotglob` is not set.