### PR TITLE
Fix table scraping XPath

### DIFF
--- a/scraper/recipe_test.go
+++ b/scraper/recipe_test.go
@@ -195,24 +195,26 @@ func TestBasicsTables(t *testing.T) {
 	if len(results) != len(*r) {
 		t.Errorf("Not match size results and recipes")
 	}
-	for _, rows := range *results[0].results.TableResult {
-		if len(rows) != 3 {
-			t.Errorf("Not match size table rows")
-		}
-		for _, row := range rows {
-			if len(row) != 4 {
-				t.Errorf("Not match size table columns")
+	for k, testCase := range results {
+		for _, rows := range *testCase.results.TableResult {
+			if len(rows) != 3 {
+				t.Errorf("Not match size table rows")
 			}
-		}
-		expects := [][]string{
-			{"a", "b", "c", "d"},
-			{"e", "f", "f", "g"},
-			{"h", "f", "f", "i"},
-		}
-		for i, expectRow := range expects {
-			for j, cell := range expectRow {
-				if rows[i][j] != cell {
-					t.Errorf("Not match table cell, expect %s != result %s", cell, rows[i][j])
+			for _, row := range rows {
+				if len(row) != 4 {
+					t.Errorf("Not match size table columns")
+				}
+			}
+			expects := [][]string{
+				{"a", "b", "c", "d"},
+				{"e", "f", "f", "g"},
+				{"h", "f", "f", "i"},
+			}
+			for i, expectRow := range expects {
+				for j, cell := range expectRow {
+					if rows[i][j] != cell {
+						t.Errorf("Not match table cell, expect %s != result %s in %s", cell, rows[i][j], (*r)[k].Type)
+					}
 				}
 			}
 		}

--- a/scraper/table_scraper.go
+++ b/scraper/table_scraper.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/andybalholm/cascadia"
+	htmlquery "github.com/antchfx/htmlquery"
 	"github.com/antchfx/xpath"
-	htmlquery "github.com/antchfx/xquery/html"
 	"golang.org/x/net/html"
 )
 
@@ -57,7 +57,7 @@ func extractTable(n *html.Node) [][]string {
 	c := map[int]map[int]*string{}
 	for i, tr := range htmlquery.Find(n, ".//tr") {
 		jFixed := 0
-		for _, td := range htmlquery.Find(tr, ".//th|.//td") {
+		for _, td := range htmlquery.Find(tr, ".//th or .//td") {
 			colspan, rowspan := parseColspanRowspan(td)
 			strVal := extractTextFromNodeRecursively(td)
 			for isFilled(c, i, jFixed) {


### PR DESCRIPTION
The "|" is sets operator.
So newer version of go breaks table cell order.

This case must be use "or" operator.

https://www.w3.org/TR/1999/REC-xpath-19991116/