### PR TITLE
go-winio is no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,4 +222,3 @@ The 3-Clause BSD License. See also LICENSE file.
 -	[andybalholm/cascadia](https://github.com/andybalholm/cascadia/) ... [BSD 2-clause "Simplified" License](https://github.com/andybalholm/cascadia/blob/master/LICENSE)
 - [spf13/cobra](https://github.com/spf13/cobra/) ... [Apache License 2.0](https://github.com/spf13/cobra/blob/master/LICENSE.txt)
   - (windows) [inconshreveable/mousetrap](https://github.com/inconshreveable/mousetrap/) ... [Apache License 2.0](https://github.com/inconshreveable/mousetrap/blob/master/LICENSE)
-  - (windows) [Microsoft/go-winio](https://github.com/Microsoft/go-winio/) ... [MIT License](https://github.com/Microsoft/go-winio/blob/master/LICENSE)

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
 go get
-go get -d github.com/inconshreveable/mousetrap
-go get -d github.com/Microsoft/go-winio
 CGO_ENABLE=0 gox -ldflags '-w -s' -output='build/scraper_{{.OS}}_{{.Arch}}'

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
 go get
-go get -d github.com/inconshreveable/mousetrap
-go get -d github.com/Microsoft/go-winio
 go test -v ./...

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,7 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=


### PR DESCRIPTION
spf13/cobra had needed this.
Remove from dependency.