### PR TITLE
Fix: GitHub Workflow trigger

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   push:
+  pull_request:
   release:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]

--- a/.github/workflows/golang-test.yml
+++ b/.github/workflows/golang-test.yml
@@ -1,6 +1,8 @@
 name: golang-test
 
-on: [push]
+on:
+  - push
+  - pull_request
 jobs:
   test:
     name: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: release
 
 on:
+  push:
+  pull_request:
   release:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,5 +1,7 @@
 name: Spellcheck
-on: [push]
+on:
+  - push
+  - pull_request
 permissions:
   contents: read
 jobs:

--- a/table-scraper-config.json
+++ b/table-scraper-config.json
@@ -1,0 +1,3 @@
+[
+  {"type": "table-xpath", "label": "Tables", "query": "//table"}
+]


### PR DESCRIPTION
GitHub Workflow was triggered only when push event was fired.
Now it is also triggered when pull_request event is fired.
This enables external contributors to run tests when they send pull requests.
(push event is fired when push is done to forked repository, but push event is not fired when push is done to kitsuyui's repository)
