### PR TITLE
Fix CLI output and config directory options

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 )
 
 var exit = os.Exit
+var createServer = server.CreateServer
 var usage = `scraper: Swiss army knife for web scraping
 
 Usage:
@@ -42,8 +43,8 @@ func main() {
 	} else if serverMode, _ := opts.Bool("server"); serverMode {
 		host, _ := opts.String("--host")
 		port, _ := opts.Int("--port")
-		confDir, _ := opts.String("--config-dir")
-		s, err := server.CreateServer(host, port, confDir)
+		confDir, _ := opts.String("--conf-dir")
+		s, err := createServer(host, port, confDir)
 		if err != nil {
 			fmt.Println(err.Error())
 			exit(1)
@@ -67,12 +68,14 @@ func main() {
 		}
 
 		if outputFilepath, err := opts.String("--output"); err == nil {
-			output, err = os.Open(outputFilepath)
+			outputFile, err := os.Create(outputFilepath)
 			if err != nil {
 				fmt.Println(err.Error())
 				exit(1)
 				return
 			}
+			defer outputFile.Close()
+			output = outputFile
 		}
 
 		configFilepath, _ := opts.String("--config")

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"errors"
+	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/docopt/docopt-go"
@@ -48,7 +52,7 @@ func TestValidateConfigNotExists(t *testing.T) {
 }
 
 func TestBasicInvalidOutput(t *testing.T) {
-	os.Args = []string{"scraper", "-c", "/dev/null", "-i", "/dev/null", "-o", ":"}
+	os.Args = []string{"scraper", "-c", "/dev/null", "-i", "/dev/null", "-o", "/"}
 	exit = func(i int) {
 		if i == 0 {
 			t.Error("exit status must not be 0")
@@ -74,6 +78,60 @@ func TestBasicInvalidConfigFile(t *testing.T) {
 			t.Error("exit status must not be 0")
 		}
 	}
+	main()
+}
+
+func TestBasicWritesOutputFile(t *testing.T) {
+	oldArgs := os.Args
+	oldExit := exit
+	defer func() {
+		os.Args = oldArgs
+		exit = oldExit
+	}()
+
+	outputFilepath := filepath.Join(t.TempDir(), "scraper-output.json")
+	os.Args = []string{
+		"scraper",
+		"-c", "test_assets/scraper-config.json",
+		"-i", "test_assets/ok.html",
+		"-o", outputFilepath,
+	}
+	exit = func(i int) {
+		t.Fatalf("unexpected exit status: %d", i)
+	}
+
+	main()
+
+	output, err := os.ReadFile(outputFilepath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(output), "test passed") {
+		t.Errorf("output does not contain scraped title: %s", output)
+	}
+}
+
+func TestServerUsesConfDirOption(t *testing.T) {
+	oldArgs := os.Args
+	oldExit := exit
+	oldCreateServer := createServer
+	defer func() {
+		os.Args = oldArgs
+		exit = oldExit
+		createServer = oldCreateServer
+	}()
+
+	confDir := t.TempDir()
+	stopErr := errors.New("stop before listen")
+	os.Args = []string{"scraper", "server", "-d", confDir}
+	exit = func(i int) {}
+	createServer = func(bindHost string, bindPort int, configDir string) (*http.Server, error) {
+		if configDir != confDir {
+			t.Errorf("configDir = %q, want %q", configDir, confDir)
+		}
+		return nil, stopErr
+	}
+
 	main()
 }
 


### PR DESCRIPTION
## Summary
- Create or truncate the `--output` path before writing scrape results.
- Read the documented `--conf-dir` option in server mode.
- Add regression coverage for output file writes and server config directory forwarding.

## Verification
- go test ./...
- git diff --check
