### PR TITLE
Pin Docker base image tags

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:latest AS builder
+FROM golang:1.26.0-alpine3.23 AS builder
 WORKDIR /workdir
 COPY ./ /workdir
 RUN go install
 RUN CGO_ENABLED=0 go build -a -installsuffix cgo -o /workdir/bin/scraper
 
-FROM alpine:latest
+FROM alpine:3.23
 RUN mkdir -p /root/server-config
 COPY --from=builder /workdir/bin/scraper /bin/scraper
 ENTRYPOINT ["/bin/scraper", "server"]


### PR DESCRIPTION
## Summary
- pin the Docker builder image to the Go toolchain version used by the project
- pin the runtime image to Alpine 3.23 instead of tracking latest

## Verification
- docker buildx imagetools inspect golang:1.26.0-alpine3.23
- docker buildx imagetools inspect alpine:3.23
- go vet ./...
- go test ./...
- actionlint .github/workflows/docker-release.yml
- docker buildx build --platform linux/amd64 --file docker/server/Dockerfile --tag kitsuyui/scraper:ci --load=false .
- git diff --check

Note: the local Docker driver does not support multi-platform builds; the PR workflow covers linux/amd64 and linux/arm64.