### PR TITLE
Return 405 for unsupported HTTP methods

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -15,6 +15,8 @@ type ServerContext struct {
 	ConfigDirectory string
 }
 
+const allowedMethods = "GET, POST, PUT, DELETE"
+
 func (s *ServerContext) setConfigDirectory(configDir string) error {
 	absPath, err := filepath.Abs(configDir)
 	if err != nil {
@@ -41,6 +43,9 @@ func (s *ServerContext) handler(w http.ResponseWriter, r *http.Request) {
 		s.handlerPUT(w, r)
 	case "DELETE":
 		s.handlerDELETE(w, r)
+	default:
+		w.Header().Set("Allow", allowedMethods)
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -116,6 +116,27 @@ func TestDeleteNotExists(t *testing.T) {
 	}
 }
 
+func TestUnsupportedMethod(t *testing.T) {
+	configPath := "/something-config.json"
+	server := httptest.NewServer(http.HandlerFunc(serverContext.handler))
+	defer server.Close()
+	req, err := http.NewRequest(http.MethodPatch, server.URL+configPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("this must be 405")
+	}
+	if allow := res.Header.Get("Allow"); allow != "GET, POST, PUT, DELETE" {
+		t.Errorf("Allow header must list supported methods")
+	}
+}
+
 func postRequest(server *httptest.Server, postHTML string, postPath string) (int, string, error) {
 	b := bytes.NewBufferString(postHTML)
 	res, err := http.Post(server.URL+postPath, "application/octet-stream", b)


### PR DESCRIPTION
## Summary
- Return `405 Method Not Allowed` for unsupported server HTTP methods.
- Include the `Allow` header listing supported methods: `GET, POST, PUT, DELETE`.
- Add a regression test for unsupported methods.

## Validation
- `gofmt -w server/server.go server/server_test.go`
- `go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`
- `go vet ./...`