### PR TITLE
Pin gitignore workflow ref

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -8,4 +8,4 @@ permissions:
   pull-requests: write
 jobs:
   update-gitignore:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@3717c78af3a5e594b7a81b063276e15fac7e08fc


### PR DESCRIPTION
## Summary
- Pin the reusable gitignore update workflow to a full commit SHA instead of the moving `main` ref.

## Verification
- `git diff --check`
- `actionlint .github/workflows/gitignore-in.yml`
- Verified the pinned workflow file is resolvable through the GitHub API.