### PR TITLE
Declare workflow token permissions

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -7,6 +7,9 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+permissions:
+  contents: read
+
 jobs:
   docker_build:
     name: Build Docker image

--- a/.github/workflows/golang-test.yml
+++ b/.github/workflows/golang-test.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: test
@@ -34,4 +38,3 @@ jobs:
 
       - name: test
         run: go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,12 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+permissions:
+  contents: read
+
 jobs:
-  goreleaser:
+  goreleaser_check:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -23,8 +27,25 @@ jobs:
 
       - run: go install
 
+  goreleaser:
+    if: github.event_name == 'release' && !github.event.release.prerelease
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+
+      - name: setup
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          check-latest: true
+          cache: true
+
+      - run: go install
+
       - name: release
-        if: github.event_name == 'release' && !github.event.release.prerelease
         # https://github.com/goreleaser/goreleaser-action
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
## Summary
- Declare explicit `GITHUB_TOKEN` permissions in the Docker release and Go test workflows.
- Keep pull request validation read-only while allowing the release publish job to retain `contents: write` for GitHub release uploads.
- Split the GoReleaser workflow into separate pull request validation and release publishing jobs so each path has the permissions it needs.

## Validation
- `actionlint .github/workflows/*.yml`
- `git diff --check origin/main...HEAD`

## Notes
- No external issue is linked; this hardens workflow token scope without changing application code.
