### PR TITLE
Send CLI errors to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,18 @@ Options:
  -d=<conf-dir> --conf-dir=<conf-dir>  Configuration directory for server mode [default: .].
 ```
 
+### Exit status
+
+CLI diagnostics are written to stderr. Successful commands exit with status `0`.
+Error statuses are:
+
+- `2`: configuration validation failed.
+- `3`: server mode startup failed.
+- `4`: input file could not be opened.
+- `5`: output file could not be created.
+- `6`: configuration file could not be opened.
+- `7`: scraping failed.
+
 ## Build
 
 ### For developing

--- a/main.go
+++ b/main.go
@@ -12,6 +12,18 @@ import (
 
 var exit = os.Exit
 var createServer = server.CreateServer
+var standardOutput io.Writer = os.Stdout
+var errorOutput io.Writer = os.Stderr
+
+const (
+	exitValidateConfig = 2
+	exitServer         = 3
+	exitInputFile      = 4
+	exitOutputFile     = 5
+	exitConfigFile     = 6
+	exitScrape         = 7
+)
+
 var usage = `scraper: Swiss army knife for web scraping
 
 Usage:
@@ -28,16 +40,25 @@ Options:
  -d=<conf-dir> --conf-dir=<conf-dir>  Configuration directory for server mode [default: .].
 `
 
+func reportError(err error, exitCode int) {
+	fmt.Fprintln(errorOutput, err.Error())
+	exit(exitCode)
+}
+
 func main() {
 	opts, _ := docopt.ParseDoc(usage)
 
 	if validate, _ := opts.Bool("validate"); validate {
 		configFilepath, _ := opts.String("--config")
 		c, err := os.Open(configFilepath)
+		if err != nil {
+			reportError(err, exitConfigFile)
+			return
+		}
+		defer c.Close()
 		err = scraper.ValidateConfigFile(c)
 		if err != nil {
-			fmt.Println(err.Error())
-			exit(1)
+			reportError(err, exitValidateConfig)
 			return
 		}
 	} else if serverMode, _ := opts.Bool("server"); serverMode {
@@ -46,11 +67,12 @@ func main() {
 		confDir, _ := opts.String("--conf-dir")
 		s, err := createServer(host, port, confDir)
 		if err != nil {
-			fmt.Println(err.Error())
-			exit(1)
+			reportError(err, exitServer)
 			return
 		}
-		s.ListenAndServe()
+		if err := s.ListenAndServe(); err != nil {
+			reportError(err, exitServer)
+		}
 		return
 	} else {
 		var confFile io.Reader
@@ -58,12 +80,12 @@ func main() {
 		var output io.Writer
 
 		input = os.Stdin
-		output = os.Stdout
+		output = standardOutput
 		if inputFilepath, err := opts.String("--input"); err == nil {
 			inputFile, err := os.Open(inputFilepath)
 			if err != nil {
-				fmt.Println(err.Error())
-				exit(1)
+				reportError(err, exitInputFile)
+				return
 			}
 			defer inputFile.Close()
 			input = inputFile
@@ -72,8 +94,7 @@ func main() {
 		if outputFilepath, err := opts.String("--output"); err == nil {
 			outputFile, err := os.Create(outputFilepath)
 			if err != nil {
-				fmt.Println(err.Error())
-				exit(1)
+				reportError(err, exitOutputFile)
 				return
 			}
 			defer outputFile.Close()
@@ -83,15 +104,13 @@ func main() {
 		configFilepath, _ := opts.String("--config")
 		confFile, err := os.Open(configFilepath)
 		if err != nil {
-			fmt.Println(err.Error())
-			exit(1)
+			reportError(err, exitConfigFile)
 			return
 		}
 
 		err = scraper.ScrapeByConfFile(confFile, input, output)
 		if err != nil {
-			fmt.Println(err.Error())
-			exit(1)
+			reportError(err, exitScrape)
 			return
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"net/http"
 	"os"
@@ -11,96 +12,139 @@ import (
 	"github.com/docopt/docopt-go"
 )
 
-func TestServerFailBindInvalidPort(t *testing.T) {
-	os.Args = []string{"scraper", "server", "-p", "-1", "-d", "."}
+type commandResult struct {
+	exited   bool
+	exitCode int
+	stdout   string
+	stderr   string
+}
+
+func runCLI(t *testing.T, args []string, setup func()) commandResult {
+	t.Helper()
+
+	oldArgs := os.Args
+	oldExit := exit
+	oldCreateServer := createServer
+	oldStandardOutput := standardOutput
+	oldErrorOutput := errorOutput
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	result := commandResult{exitCode: -1}
+
+	os.Args = append([]string(nil), args...)
+	standardOutput = &stdout
+	errorOutput = &stderr
 	exit = func(i int) {
-		if i == 0 {
-			t.Error("exit status must not be 0")
-		}
+		result.exited = true
+		result.exitCode = i
 	}
+	if setup != nil {
+		setup()
+	}
+
+	t.Cleanup(func() {
+		os.Args = oldArgs
+		exit = oldExit
+		createServer = oldCreateServer
+		standardOutput = oldStandardOutput
+		errorOutput = oldErrorOutput
+	})
+
 	main()
+	result.stdout = stdout.String()
+	result.stderr = stderr.String()
+	return result
+}
+
+func assertExitedNonZero(t *testing.T, result commandResult) {
+	t.Helper()
+
+	if !result.exited {
+		t.Fatal("expected command to exit")
+	}
+	if result.exitCode == 0 {
+		t.Fatal("exit status must not be 0")
+	}
+	if result.stdout != "" {
+		t.Errorf("stdout = %q, want empty", result.stdout)
+	}
+	if result.stderr == "" {
+		t.Error("stderr is empty")
+	}
+}
+
+func TestServerFailBindInvalidPort(t *testing.T) {
+	result := runCLI(t, []string{"scraper", "server", "-p", "-1", "-d", "."}, nil)
+	assertExitedNonZero(t, result)
 }
 
 func TestValidateConfig(t *testing.T) {
-	os.Args = []string{"scraper", "validate", "-c", "../test_assets/scraper-config.json"}
-	exit = func(i int) {
-		if i == 0 {
-			t.Error("exit status must not be 0")
-		}
+	result := runCLI(t, []string{"scraper", "validate", "-c", "test_assets/scraper-config.json"}, nil)
+	if result.exited {
+		t.Fatalf("unexpected exit status: %d", result.exitCode)
 	}
-	main()
+	if result.stdout != "" {
+		t.Errorf("stdout = %q, want empty", result.stdout)
+	}
+	if result.stderr != "" {
+		t.Errorf("stderr = %q, want empty", result.stderr)
+	}
 }
 
 func TestValidateConfigInvalid(t *testing.T) {
-	os.Args = []string{"scraper", "validate", "-c", "../test_assets/invalid-config.json"}
-	exit = func(i int) {
-		if i == 0 {
-			t.Error("exit status must not be 0")
-		}
-	}
-	main()
+	result := runCLI(t, []string{"scraper", "validate", "-c", "test_assets/invalid-config.json"}, nil)
+	assertExitedNonZero(t, result)
 }
 
 func TestValidateConfigNotExists(t *testing.T) {
-	os.Args = []string{"scraper", "validate", "-c", "../test_assets/not-exists.json"}
-	exit = func(i int) {
-		if i == 0 {
-			t.Error("exit status must not be 0")
-		}
+	result := runCLI(t, []string{"scraper", "validate", "-c", "test_assets/not-exists.json"}, nil)
+	if !result.exited {
+		t.Fatal("expected command to exit")
 	}
-	main()
+	if result.exitCode != exitConfigFile {
+		t.Fatalf("exit status = %d, want %d", result.exitCode, exitConfigFile)
+	}
+	if result.stdout != "" {
+		t.Errorf("stdout = %q, want empty", result.stdout)
+	}
+	if result.stderr == "" {
+		t.Error("stderr is empty")
+	}
 }
 
 func TestBasicInvalidOutput(t *testing.T) {
-	os.Args = []string{"scraper", "-c", "/dev/null", "-i", "/dev/null", "-o", "/"}
-	exit = func(i int) {
-		if i == 0 {
-			t.Error("exit status must not be 0")
-		}
-	}
-	main()
+	result := runCLI(t, []string{"scraper", "-c", "/dev/null", "-i", "/dev/null", "-o", "/"}, nil)
+	assertExitedNonZero(t, result)
 }
 
 func TestBasicInvalidInput(t *testing.T) {
-	os.Args = []string{"scraper", "-c", "/dev/null", "-i", ":", "-o", "/dev/null"}
-	exit = func(i int) {
-		if i == 0 {
-			t.Error("exit status must not be 0")
-		}
-	}
-	main()
+	result := runCLI(t, []string{"scraper", "-c", "/dev/null", "-i", ":", "-o", "/dev/null"}, nil)
+	assertExitedNonZero(t, result)
 }
 
 func TestBasicInvalidConfigFile(t *testing.T) {
-	os.Args = []string{"scraper", "-c", ":", "-i", "/dev/null", "-o", "/dev/null"}
-	exit = func(i int) {
-		if i == 0 {
-			t.Error("exit status must not be 0")
-		}
-	}
-	main()
+	result := runCLI(t, []string{"scraper", "-c", ":", "-i", "/dev/null", "-o", "/dev/null"}, nil)
+	assertExitedNonZero(t, result)
 }
 
 func TestBasicWritesOutputFile(t *testing.T) {
-	oldArgs := os.Args
-	oldExit := exit
-	defer func() {
-		os.Args = oldArgs
-		exit = oldExit
-	}()
-
 	outputFilepath := filepath.Join(t.TempDir(), "scraper-output.json")
-	os.Args = []string{
+	result := runCLI(t, []string{
 		"scraper",
 		"-c", "test_assets/scraper-config.json",
 		"-i", "test_assets/ok.html",
 		"-o", outputFilepath,
+	}, nil)
+	if result.exited {
+		t.Fatalf("unexpected exit status: %d", result.exitCode)
 	}
-	exit = func(i int) {
-		t.Fatalf("unexpected exit status: %d", i)
+	if result.stdout != "" {
+		t.Errorf("stdout = %q, want empty", result.stdout)
 	}
-
-	main()
+	if result.stderr != "" {
+		t.Errorf("stderr = %q, want empty", result.stderr)
+	}
 
 	output, err := os.ReadFile(outputFilepath)
 	if err != nil {
@@ -112,27 +156,122 @@ func TestBasicWritesOutputFile(t *testing.T) {
 }
 
 func TestServerUsesConfDirOption(t *testing.T) {
-	oldArgs := os.Args
-	oldExit := exit
-	oldCreateServer := createServer
-	defer func() {
-		os.Args = oldArgs
-		exit = oldExit
-		createServer = oldCreateServer
-	}()
-
 	confDir := t.TempDir()
 	stopErr := errors.New("stop before listen")
-	os.Args = []string{"scraper", "server", "-d", confDir}
-	exit = func(i int) {}
-	createServer = func(bindHost string, bindPort int, configDir string) (*http.Server, error) {
-		if configDir != confDir {
-			t.Errorf("configDir = %q, want %q", configDir, confDir)
+	result := runCLI(t, []string{"scraper", "server", "-d", confDir}, func() {
+		createServer = func(bindHost string, bindPort int, configDir string) (*http.Server, error) {
+			if configDir != confDir {
+				t.Errorf("configDir = %q, want %q", configDir, confDir)
+			}
+			return nil, stopErr
 		}
-		return nil, stopErr
+	})
+
+	if !result.exited {
+		t.Fatal("expected command to exit")
+	}
+	if result.exitCode != exitServer {
+		t.Fatalf("exit status = %d, want %d", result.exitCode, exitServer)
+	}
+	if !strings.Contains(result.stderr, stopErr.Error()) {
+		t.Errorf("stderr = %q, want to contain %q", result.stderr, stopErr.Error())
+	}
+}
+
+func TestCLIErrorPathsUseDistinctExitCodes(t *testing.T) {
+	cases := []struct {
+		name           string
+		args           func(t *testing.T) []string
+		setup          func()
+		wantExitCode   int
+		stderrContains string
+	}{
+		{
+			name: "validate config",
+			args: func(t *testing.T) []string {
+				return []string{"scraper", "validate", "-c", "test_assets/invalid-config.json"}
+			},
+			wantExitCode:   exitValidateConfig,
+			stderrContains: "Error:",
+		},
+		{
+			name: "server create",
+			args: func(t *testing.T) []string {
+				return []string{"scraper", "server", "-d", "."}
+			},
+			setup: func() {
+				createServer = func(bindHost string, bindPort int, configDir string) (*http.Server, error) {
+					return nil, errors.New("server unavailable")
+				}
+			},
+			wantExitCode:   exitServer,
+			stderrContains: "server unavailable",
+		},
+		{
+			name: "input file",
+			args: func(t *testing.T) []string {
+				return []string{
+					"scraper",
+					"-c", "test_assets/config.json",
+					"-i", "test_assets/not-exists.html",
+					"-o", filepath.Join(t.TempDir(), "output.json"),
+				}
+			},
+			wantExitCode: exitInputFile,
+		},
+		{
+			name: "output file",
+			args: func(t *testing.T) []string {
+				return []string{
+					"scraper",
+					"-c", "test_assets/config.json",
+					"-i", "test_assets/ok.html",
+					"-o", t.TempDir(),
+				}
+			},
+			wantExitCode: exitOutputFile,
+		},
+		{
+			name: "config file",
+			args: func(t *testing.T) []string {
+				return []string{"scraper", "-c", "test_assets/not-exists.json"}
+			},
+			wantExitCode: exitConfigFile,
+		},
+		{
+			name: "scrape",
+			args: func(t *testing.T) []string {
+				return []string{
+					"scraper",
+					"-c", "test_assets/config.json",
+					"-i", "/",
+					"-o", filepath.Join(t.TempDir(), "output.json"),
+				}
+			},
+			wantExitCode: exitScrape,
+		},
 	}
 
-	main()
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			result := runCLI(t, tt.args(t), tt.setup)
+			if !result.exited {
+				t.Fatal("expected command to exit")
+			}
+			if result.exitCode != tt.wantExitCode {
+				t.Fatalf("exit status = %d, want %d", result.exitCode, tt.wantExitCode)
+			}
+			if result.stdout != "" {
+				t.Errorf("stdout = %q, want empty", result.stdout)
+			}
+			if result.stderr == "" {
+				t.Fatal("stderr is empty")
+			}
+			if tt.stderrContains != "" && !strings.Contains(result.stderr, tt.stderrContains) {
+				t.Errorf("stderr = %q, want to contain %q", result.stderr, tt.stderrContains)
+			}
+		})
+	}
 }
 
 func TestMainCommand(t *testing.T) {


### PR DESCRIPTION
Summary:
- Route CLI diagnostics to stderr so stdout remains reserved for command output.
- Add distinct exit codes for validation, server startup, input file, output file, config file, and scrape failures.
- Document the exit status contract and add tests for stderr/no-stdout behavior.

Verification:
- gofmt -w main.go main_test.go && test -z "$(gofmt -l main.go main_test.go)"
- go test ./...
- go install
- go vet ./... && go mod tidy && git diff --exit-code -- go.mod go.sum
- go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...
- typos
- docker buildx build --file docker/server/Dockerfile --tag kitsuyui/scraper:ci --platform linux/amd64,linux/arm64 --output=type=cacheonly .
