### PR TITLE
fix: use atomic write in handlerPUT to prevent concurrent corruption

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -96,14 +96,29 @@ func (s *ServerContext) handlerPOST(w http.ResponseWriter, r *http.Request) {
 
 func (s *ServerContext) handlerPUT(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	confFile, err := os.Create(s.confFilePathFromRequest(r))
+	targetPath := s.confFilePathFromRequest(r)
+
+	tmpFile, err := os.CreateTemp(filepath.Dir(targetPath), ".put-tmp-*")
 	if err != nil {
 		errorStatus(w, err)
 		return
 	}
-	defer confFile.Close()
-	_, err = io.Copy(confFile, r.Body)
-	if err != nil {
+	tmpPath := tmpFile.Name()
+
+	_, copyErr := io.Copy(tmpFile, r.Body)
+	closeErr := tmpFile.Close()
+	if copyErr != nil || closeErr != nil {
+		os.Remove(tmpPath)
+		if copyErr != nil {
+			errorStatus(w, copyErr)
+		} else {
+			errorStatus(w, closeErr)
+		}
+		return
+	}
+
+	if err := os.Rename(tmpPath, targetPath); err != nil {
+		os.Remove(tmpPath)
 		errorStatus(w, err)
 		return
 	}


### PR DESCRIPTION
## Summary

`handlerPUT` in `server/server.go` previously used `os.Create` (which truncates the target file) followed by `io.Copy`. Under concurrent PUT requests to the same path, goroutine B could truncate the file while goroutine A was still writing, producing a corrupted or empty config file.

This PR replaces the write path with an atomic write-via-rename pattern:
1. Write the request body to a temporary file in the same directory
2. Rename the temp file to the target path atomically

`os.Rename` is atomic on POSIX filesystems for same-filesystem renames, so concurrent PUTs result in "last rename wins" rather than interleaved writes.

## Changes

- `server/server.go`: replaced `os.Create` + `io.Copy` in `handlerPUT` with `os.CreateTemp` + `io.Copy` + `os.Rename`
- Temp file is cleaned up on any error path before returning

## Verification

All existing tests pass with `-race`:

```
ok  github.com/kitsuyui/scraper/server    coverage: 64.0%
```

`go vet ./...` reports no issues. `staticcheck ./...` reports no new findings in the changed file (pre-existing findings in unrelated files only).

## Trade-offs

- **Concurrent writes**: both writes complete to temp files; the last `os.Rename` wins. This is correct PUT semantics (idempotent, last-writer-wins).
- **Cross-filesystem**: `os.Rename` is not atomic across filesystems. Since temp file and target are in the same directory, this is not a concern in practice.
