### PR TITLE
fix: limit HTTP request body size to prevent unbounded memory/disk consumption

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +11,8 @@ import (
 
 	"github.com/kitsuyui/scraper/scraper"
 )
+
+const maxBodyBytes = 10 * 1024 * 1024 // 10 MB
 
 type ServerContext struct {
 	ConfigDirectory string
@@ -56,7 +59,10 @@ func (s *ServerContext) confFilePathFromRequest(r *http.Request) string {
 }
 
 func errorStatus(w http.ResponseWriter, err error) {
-	if os.IsNotExist(err) {
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
+	} else if os.IsNotExist(err) {
 		w.WriteHeader(http.StatusNotFound)
 		w.Write([]byte(`{"Error": "The file does not exists"}`))
 	} else if os.IsPermission(err) {
@@ -91,7 +97,9 @@ func (s *ServerContext) handlerPOST(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer confFile.Close()
-	scraper.ScrapeByConfFile(confFile, r.Body, w)
+	if err := scraper.ScrapeByConfFile(confFile, r.Body, w); err != nil {
+		errorStatus(w, err)
+	}
 }
 
 func (s *ServerContext) handlerPUT(w http.ResponseWriter, r *http.Request) {
@@ -125,6 +133,7 @@ func CreateServer(bindHost string, bindPort int, configDir string) (*http.Server
 		return nil, err
 	}
 	bindAddr := fmt.Sprintf("%s:%d", bindHost, bindPort)
-	server := &http.Server{Addr: bindAddr, Handler: http.HandlerFunc(sc.handler)}
+	handler := http.MaxBytesHandler(http.HandlerFunc(sc.handler), maxBodyBytes)
+	server := &http.Server{Addr: bindAddr, Handler: handler}
 	return server, nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -134,6 +135,42 @@ func TestUnsupportedMethod(t *testing.T) {
 	}
 	if allow := res.Header.Get("Allow"); allow != "GET, POST, PUT, DELETE" {
 		t.Errorf("Allow header must list supported methods")
+	}
+}
+
+func TestBodySizeLimit(t *testing.T) {
+	content := `[{"type": "css", "label": "title", "query": "title"}]`
+	configPath := "/size-limit-test-config.json"
+
+	const testLimit = 100
+	limitedHandler := http.MaxBytesHandler(http.HandlerFunc(serverContext.handler), testLimit)
+	server := httptest.NewServer(limitedHandler)
+	defer server.Close()
+
+	status, _, err := putRequest(server, content, configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusOK {
+		t.Errorf("PUT config: expected 200, got %d", status)
+	}
+
+	largeBody := strings.Repeat("x", testLimit+1)
+
+	status, _, err = postRequest(server, largeBody, configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusRequestEntityTooLarge {
+		t.Errorf("POST over limit: expected 413, got %d", status)
+	}
+
+	status, _, err = putRequest(server, largeBody, configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusRequestEntityTooLarge {
+		t.Errorf("PUT over limit: expected 413, got %d", status)
 	}
 }
 


### PR DESCRIPTION
## Summary

`handlerPOST` and `handlerPUT` previously read the HTTP request body without any size
limit. A large body sent to `POST` would expand unboundedly in a `bytes.Buffer` on the
heap; a large body sent to `PUT` would fill the disk without bound.

## Changes

- Wrap the server handler with `http.MaxBytesHandler` (10 MB limit) in `CreateServer`.
  All methods are covered by a single, centrally applied limit.
- Return **413 Request Entity Too Large** when the body exceeds the limit by handling
  `*http.MaxBytesError` in `errorStatus`.
- Fix `handlerPOST` to propagate errors returned by `ScrapeByConfFile` (previously
  silently discarded).

## Verification

- `TestBodySizeLimit` — new test that sets a 100-byte limit and verifies POST and PUT
  both return 413 when the body exceeds it; existing tests still pass.
- `go vet ./server/...` — no issues.
- `staticcheck ./server/...` — 1 pre-existing `io/ioutil` deprecation warning in the
  test file (not introduced by this change).

## Trade-offs

The 10 MB cap is a pragmatic upper bound for HTML scraping. If legitimate use cases
require larger inputs the constant can be adjusted.
