### PR TITLE
Fix table scraping for header cells

### DIFF
--- a/scraper/recipe_test.go
+++ b/scraper/recipe_test.go
@@ -221,6 +221,66 @@ func TestBasicsTables(t *testing.T) {
 	}
 }
 
+func TestTableHeaderCells(t *testing.T) {
+	r := &recipes{{
+		Type:  "table-xpath",
+		Query: "//table",
+		Label: "table1",
+	}, {
+		Type:  "table-css",
+		Query: "table",
+		Label: "table1",
+	}}
+	cr, err := r.compile()
+	if err != nil {
+		t.Errorf("Must not be error on this recipe.")
+	}
+	input := bytes.NewBufferString(`
+<html>
+	<body>
+		<table border=1>
+		  <tr><th>Name</th><th>Score</th></tr>
+		  <tr><th>Alice</th><td>10</td></tr>
+		</table>
+	</body>
+</html>
+`)
+	results, err := cr.extractAll(input)
+	if err != nil {
+		t.Errorf("This is valid HTML File")
+	}
+	if len(results) != len(*r) {
+		t.Errorf("Not match size results and recipes")
+	}
+	expects := [][]string{
+		{"Name", "Score"},
+		{"Alice", "10"},
+	}
+	for k, testCase := range results {
+		if len(*testCase.results.TableResult) != 1 {
+			t.Errorf("Not match size table results in %s", (*r)[k].Type)
+			continue
+		}
+		for _, rows := range *testCase.results.TableResult {
+			if len(rows) != len(expects) {
+				t.Errorf("Not match size table rows in %s", (*r)[k].Type)
+				continue
+			}
+			for i, expectRow := range expects {
+				if len(rows[i]) != len(expectRow) {
+					t.Errorf("Not match size table columns in %s", (*r)[k].Type)
+					continue
+				}
+				for j, cell := range expectRow {
+					if rows[i][j] != cell {
+						t.Errorf("Not match table cell, expect %s != result %s in %s", cell, rows[i][j], (*r)[k].Type)
+					}
+				}
+			}
+		}
+	}
+}
+
 func TestInvalidRowspanColspan(t *testing.T) {
 	r := &recipes{
 		{

--- a/scraper/table_scraper.go
+++ b/scraper/table_scraper.go
@@ -57,7 +57,7 @@ func extractTable(n *html.Node) [][]string {
 	c := map[int]map[int]*string{}
 	for i, tr := range htmlquery.Find(n, ".//tr") {
 		jFixed := 0
-		for _, td := range htmlquery.Find(tr, ".//th or .//td") {
+		for _, td := range htmlquery.Find(tr, ".//th | .//td") {
 			colspan, rowspan := parseColspanRowspan(td)
 			strVal := extractTextFromNodeRecursively(td)
 			for isFilled(c, i, jFixed) {


### PR DESCRIPTION
## Summary
- Use the XPath union operator when collecting table header and data cells.
- Add regression coverage for tables that include `th` cells through both table extractors.

## Verification
- `gofmt -w scraper/table_scraper.go scraper/recipe_test.go`
- `go test ./scraper -run TestTableHeaderCells -count=1`
- `git diff --check`
- `go install`
- `typos .`
- `go vet ./...`
- `go mod tidy`
- `go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`
- `docker buildx build --platform linux/amd64,linux/arm64 -f docker/server/Dockerfile -t kitsuyui/scraper:ci --progress=plain .`

## Notes
- `staticcheck` was also run as an adjacent check and reported existing baseline findings outside the changed files.
