### PR TITLE
fix: guard against nil dereference in scrapeResult.MarshalJSON

### DIFF
--- a/scraper/recipe.go
+++ b/scraper/recipe.go
@@ -23,6 +23,9 @@ type scrapeResult struct {
 }
 
 func (sr *scrapeResult) MarshalJSON() ([]byte, error) {
+	if sr.results == nil {
+		return nil, fmt.Errorf("scrapeResult.MarshalJSON: extractResult is nil")
+	}
 	if sr.results.TableResult != nil {
 		return json.Marshal(&struct {
 			recipe
@@ -31,6 +34,9 @@ func (sr *scrapeResult) MarshalJSON() ([]byte, error) {
 			recipe:  sr.recipe,
 			Results: *sr.results.TableResult,
 		})
+	}
+	if sr.results.PlainResult == nil {
+		return nil, fmt.Errorf("scrapeResult.MarshalJSON: both TableResult and PlainResult are nil")
 	}
 	return json.Marshal(&struct {
 		recipe
@@ -129,7 +135,7 @@ func (r recipe) compile() (*compiledRecipe, error) {
 			textScraper: textScraper,
 		}, nil
 	}
-	return nil, fmt.Errorf("Unimplemented type: %s", r.Type)
+	return nil, fmt.Errorf("unimplemented type: %s", r.Type)
 }
 
 func (crs compiledRecipes) extractAll(input io.Reader) ([]scrapeResult, error) {
@@ -142,7 +148,7 @@ func (crs compiledRecipes) extractAll(input io.Reader) ([]scrapeResult, error) {
 	input = strings.NewReader(htmlText)
 	doc, err := htmlquery.Parse(input)
 	if err != nil {
-		return nil, fmt.Errorf("If this error is occurred, please tell me HTML for adding unit-test case.%s", err)
+		return nil, fmt.Errorf("if this error is occurred, please tell me HTML for adding unit-test case.%s", err)
 	}
 	var ers []scrapeResult
 	for _, cr := range crs {

--- a/scraper/recipe_test.go
+++ b/scraper/recipe_test.go
@@ -279,3 +279,25 @@ func TestRegexInvalid(t *testing.T) {
 		t.Errorf("Must be error when invalid regular expression is passed.")
 	}
 }
+
+func TestMarshalJSONNilResults(t *testing.T) {
+	sr := &scrapeResult{
+		recipe:  recipe{Type: "css", Query: "title", Label: "title"},
+		results: nil,
+	}
+	_, err := sr.MarshalJSON()
+	if err == nil {
+		t.Errorf("MarshalJSON must return error when results is nil")
+	}
+}
+
+func TestMarshalJSONBothResultsNil(t *testing.T) {
+	sr := &scrapeResult{
+		recipe:  recipe{Type: "css", Query: "title", Label: "title"},
+		results: &extractResult{PlainResult: nil, TableResult: nil},
+	}
+	_, err := sr.MarshalJSON()
+	if err == nil {
+		t.Errorf("MarshalJSON must return error when both PlainResult and TableResult are nil")
+	}
+}


### PR DESCRIPTION
## Summary

`scrapeResult.MarshalJSON` accessed `sr.results.TableResult` without first checking whether `sr.results` itself is nil, and dereferenced `sr.results.PlainResult` without a nil check. Both paths could panic if a `domScraper` implementation returns a nil `*extractResult`.

While all current scraper implementations (`css_scraper.go`, `xpath_scraper.go`, `table_scraper.go`) return non-nil results, the `domScraper` interface permits `nil` returns at the type level, so future implementations could trigger the panic path.

## Changes

- **`scraper/recipe.go`**: Add two nil guards in `MarshalJSON`:
  - Return an error (instead of panicking) when `sr.results` is nil
  - Return an error when both `TableResult` and `PlainResult` are nil
  - Fix pre-existing capitalized error strings to comply with Go error conventions (`ST1005`)

- **`scraper/recipe_test.go`**: Add `TestMarshalJSONNilResults` and `TestMarshalJSONBothResultsNil` to cover the new guard paths

## Verification

```
go test -v -race ./...     # all tests pass
go vet ./...               # no new issues
staticcheck ./...          # ST1005 issues in this file resolved
```
