### PR TITLE
Handle scalar XPath results without panic

### DIFF
--- a/scraper/recipe_test.go
+++ b/scraper/recipe_test.go
@@ -60,6 +60,59 @@ func TestXPathInvalid(t *testing.T) {
 	}
 }
 
+func TestXPathScalarResults(t *testing.T) {
+	r := &recipes{
+		{
+			Type:  "xpath",
+			Query: "count(//p)",
+			Label: "paragraph-count",
+		}, {
+			Type:  "xpath",
+			Query: "string(//h1)",
+			Label: "heading",
+		}, {
+			Type:  "xpath",
+			Query: "boolean(//p)",
+			Label: "has-paragraph",
+		},
+	}
+	cr, err := r.compile()
+	if err != nil {
+		t.Fatalf("Must not be error on this recipe.")
+	}
+	input := bytes.NewBufferString(`
+<html>
+  <body>
+    <h1>Heading</h1>
+    <p>first</p>
+    <p>second</p>
+  </body>
+</html>
+`)
+	results, err := cr.extractAll(input)
+	if err != nil {
+		t.Fatalf("This is valid HTML File")
+	}
+	if len(results) != len(*r) {
+		t.Fatalf("Not match size results and recipes")
+	}
+	expects := []string{"2", "Heading", "true"}
+	for i, expect := range expects {
+		if results[i].results.PlainResult == nil {
+			t.Errorf("PlainResult is nil for %s", (*r)[i].Type)
+			continue
+		}
+		actual := *results[i].results.PlainResult
+		if len(actual) != 1 {
+			t.Errorf("Not match result count, expect 1 != result %d", len(actual))
+			continue
+		}
+		if actual[0] != expect {
+			t.Errorf("Not match scalar XPath result, expect %s != result %s", expect, actual[0])
+		}
+	}
+}
+
 func TestTableXPathInvalid(t *testing.T) {
 	_, err := (&recipe{
 		Type:  "table-xpath",

--- a/scraper/xpath_scraper.go
+++ b/scraper/xpath_scraper.go
@@ -1,6 +1,9 @@
 package scraper
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/antchfx/xpath"
 	htmlquery "github.com/antchfx/xquery/html"
 	"golang.org/x/net/html"
@@ -20,10 +23,21 @@ func xPathScraperFromQuery(query string) (*xPathScraper, error) {
 
 func (x xPathScraper) extractFromNode(n *html.Node) *extractResult {
 	nav := htmlquery.CreateXPathNavigator(n)
-	iter := x.query.Evaluate(nav).(*xpath.NodeIterator)
 	var ret []string
-	for iter.MoveNext() {
-		ret = append(ret, iter.Current().Value())
+	switch result := x.query.Evaluate(nav).(type) {
+	case *xpath.NodeIterator:
+		for result.MoveNext() {
+			ret = append(ret, result.Current().Value())
+		}
+	case string:
+		ret = append(ret, result)
+	case float64:
+		ret = append(ret, strconv.FormatFloat(result, 'f', -1, 64))
+	case bool:
+		ret = append(ret, strconv.FormatBool(result))
+	case nil:
+	default:
+		ret = append(ret, fmt.Sprint(result))
 	}
 	return &extractResult{PlainResult: &ret}
 }


### PR DESCRIPTION
## Summary
- Normalize XPath evaluation results before building plain scrape results.
- Return scalar XPath values such as `count`, `string`, and `boolean` as single plain results instead of panicking.
- Add regression coverage for scalar XPath expressions.

## Verification
- `gofmt -w scraper/xpath_scraper.go scraper/recipe_test.go`
- `go test ./scraper -run TestXPathScalarResults -count=1`
- `git diff --check`
- `go install`
- `typos .`
- `go vet ./...`
- `go mod tidy`
- `go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`
- `docker buildx build --platform linux/amd64,linux/arm64 -f docker/server/Dockerfile -t kitsuyui/scraper:ci --progress=plain .`

## Notes
- `staticcheck` was also run as an adjacent check and reported existing baseline findings outside the changed files.
