### PR TITLE
fix: set ReadTimeout, WriteTimeout, and IdleTimeout on http.Server

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/kitsuyui/scraper/scraper"
 )
@@ -149,6 +150,12 @@ func CreateServer(bindHost string, bindPort int, configDir string) (*http.Server
 	}
 	bindAddr := fmt.Sprintf("%s:%d", bindHost, bindPort)
 	handler := http.MaxBytesHandler(http.HandlerFunc(sc.handler), maxBodyBytes)
-	server := &http.Server{Addr: bindAddr, Handler: handler}
+	server := &http.Server{
+		Addr:         bindAddr,
+		Handler:      handler,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 60 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
 	return server, nil
 }


### PR DESCRIPTION
## Summary

`CreateServer` was returning an `http.Server` with no timeout configuration. Without
timeouts, a client that sends a request body slowly (or never completes it) can hold a
goroutine indefinitely, and a client that never reads the response can block the write-side
goroutine. This allows slow-loris-style resource exhaustion under sustained load.

The Go `net/http` documentation explicitly recommends setting timeouts on production servers.

## Changes

- `server/server.go`: set `ReadTimeout: 30s`, `WriteTimeout: 60s`, `IdleTimeout: 120s` on
  the `http.Server` returned by `CreateServer`.

## Rationale

- **ReadTimeout (30 s)**: bounds the time to receive the full request body. The POST handler
  reads the body via `scraper.ScrapeByConfFile`, so 30 s is generous for any realistic input.
- **WriteTimeout (60 s)**: bounds the time to send the response after reading the request.
  Scraping is CPU-bound with no outbound HTTP calls, so 60 s covers even large documents.
- **IdleTimeout (120 s)**: closes keep-alive connections that sit idle, freeing file
  descriptors without forcing short-lived connections.

## Verification

All existing tests pass (`go test -v -race ./...`). The server tests in `server/server_test.go`
use `httptest.NewServer` and are not affected by the timeout values.

## Trade-offs

The timeout values are hard-coded. If a consumer needs different limits (e.g. very large
HTML bodies), they would need to override the returned `*http.Server` fields after calling
`CreateServer`. Making them configurable is a structural change left for a future iteration.
