### PR TITLE
Return JSON encode errors from scrape output

### DIFF
--- a/scraper/file.go
+++ b/scraper/file.go
@@ -27,8 +27,7 @@ func scrapeByCompiledRecipes(cr compiledRecipes, input io.Reader, output io.Writ
 	}
 	e := json.NewEncoder(output)
 	e.SetIndent(" ", "  ")
-	e.Encode(ers)
-	return nil
+	return e.Encode(ers)
 }
 
 func compileConfigFile(f io.Reader) (compiledRecipes, error) {

--- a/scraper/file_test.go
+++ b/scraper/file_test.go
@@ -3,9 +3,18 @@ package scraper
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"os"
 	"testing"
 )
+
+type errWriter struct {
+	err error
+}
+
+func (w errWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
 
 func TestScrapeByConfFileInvalid(t *testing.T) {
 	testFilepath := "../test_assets/invalid-config.json"
@@ -58,6 +67,24 @@ func TestScrapeByConfFile(t *testing.T) {
 	err = ScrapeByConfFile(invalidConf, input, output)
 	if err != nil {
 		t.Errorf("Must not be error on valid config file: %s", testFilepath)
+	}
+}
+
+func TestScrapeByConfFileReturnsEncodeError(t *testing.T) {
+	testFilepath := "../test_assets/config.json"
+	testHTMLFilepath := "../test_assets/ok.html"
+	conf, err := os.Open(testFilepath)
+	if err != nil {
+		t.Fatalf("Must be opened %s", testFilepath)
+	}
+	input, err := os.Open(testHTMLFilepath)
+	if err != nil {
+		t.Fatalf("Must be opened %s", testHTMLFilepath)
+	}
+	writeErr := errors.New("write failed")
+	err = ScrapeByConfFile(conf, input, errWriter{err: writeErr})
+	if !errors.Is(err, writeErr) {
+		t.Errorf("Must return output write error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Return errors from JSON encoding when writing scrape results.
- Add regression coverage for output writers that fail during `ScrapeByConfFile`.

## Verification
- `gofmt -w scraper/file.go scraper/file_test.go`
- `go test ./scraper -run TestScrapeByConfFileReturnsEncodeError -count=1`
- `git diff --check`
- `go install`
- `typos .`
- `go vet ./...`
- `go mod tidy`
- `go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`
- `docker buildx build --platform linux/amd64,linux/arm64 -f docker/server/Dockerfile -t kitsuyui/scraper:ci --progress=plain .`

## Notes
- `staticcheck` was also run as an adjacent check and reported existing baseline findings outside the changed files.
