### PR TITLE
fix: restrict extractTable XPath to direct-child rows to prevent nested-table leakage

### DIFF
--- a/scraper/recipe_test.go
+++ b/scraper/recipe_test.go
@@ -221,6 +221,45 @@ func TestBasicsTables(t *testing.T) {
 	}
 }
 
+func TestNestedTableNoLeakage(t *testing.T) {
+	r := &recipes{{
+		Type:  "table-xpath",
+		Query: "//table[not(ancestor::table)]",
+		Label: "outer",
+	}, {
+		Type:  "table-css",
+		Query: "table",
+		Label: "outer",
+	}}
+	cr, err := r.compile()
+	if err != nil {
+		t.Errorf("Must not be error on this recipe.")
+	}
+	input := bytes.NewBufferString(`
+<html>
+  <body>
+    <table>
+      <tr>
+        <td><table><tr><td>inner</td></tr></table></td>
+        <td>outer</td>
+      </tr>
+    </table>
+  </body>
+</html>
+`)
+	results, err := cr.extractAll(input)
+	if err != nil {
+		t.Errorf("This is valid HTML File")
+	}
+	for k, testCase := range results {
+		for _, rows := range *testCase.results.TableResult {
+			if len(rows) != 1 {
+				t.Errorf("Expected 1 row in outer table (no nested-table row leakage), got %d in %s", len(rows), (*r)[k].Type)
+			}
+		}
+	}
+}
+
 func TestInvalidRowspanColspan(t *testing.T) {
 	r := &recipes{
 		{

--- a/scraper/table_scraper.go
+++ b/scraper/table_scraper.go
@@ -55,7 +55,7 @@ func extractTable(n *html.Node) [][]string {
 	colmax := 0
 	rowmax := 0
 	c := map[int]map[int]*string{}
-	for i, tr := range htmlquery.Find(n, ".//tr") {
+	for i, tr := range htmlquery.Find(n, "./tr | ./tbody/tr | ./thead/tr | ./tfoot/tr") {
 		jFixed := 0
 		for _, td := range htmlquery.Find(tr, ".//th or .//td") {
 			colspan, rowspan := parseColspanRowspan(td)


### PR DESCRIPTION
## Summary

`extractTable` used the XPath expression `.//tr`, whose `//` axis matches all descendant
`<tr>` elements — including those inside nested `<table>` elements. When scraping HTML like:

```html
<table>
  <tr>
    <td><table><tr><td>inner</td></tr></table></td>
    <td>outer</td>
  </tr>
</table>
```

the inner `<tr>` was appended as a second row of the outer table, silently producing wrong
data without any error.

## Changes

- **`scraper/table_scraper.go`**: replace `.//tr` with `./tr | ./tbody/tr | ./thead/tr | ./tfoot/tr`.
  This restricts row enumeration to direct children of the table (or its `<tbody>`,
  `<thead>`, `<tfoot>` sections), so nested tables are ignored.
- **`scraper/recipe_test.go`**: add `TestNestedTableNoLeakage` that reproduces the leakage
  scenario and asserts the outer table contains exactly one row.

## Rationale

The direct-child XPath is the correct scope for row enumeration: each `<table>` element
owns its own rows, and a nested `<table>` starts an independent scope. The Go
`golang.org/x/net/html` parser inserts implicit `<tbody>` elements, so `./tbody/tr` is
needed in addition to `./tr` to match rows in standard markup.

## Verification

All existing tests pass (`go test -v -race ./...`). The new test fails on the old XPath
and passes on the fixed one.

## Trade-offs

The XPath union expression covers `<tbody>`, `<thead>`, and `<tfoot>`. HTML with `<tr>`
placed directly under `<table>` (non-standard but accepted by some parsers) is also covered
by `./tr`. This approach has no known regressions for valid HTML.
