### PR TITLE
docs: clarify regex type returns only the first match

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,27 @@ $ scraper < index.html
 ]
 ```
 
+### Behavior notes for `regex` type
+
+**First match only.** Unlike `css` and `xpath` types which return all matching nodes,
+the `regex` type returns only the **first match** found in the input text.
+
+**Capture groups.** When the pattern contains capture groups (parentheses), the `results`
+array includes the full match at index 0 followed by each capture group:
+
+```
+query: "Cat, (.*?), Snake"
+input: "Cat, Dog, Snake and Cat, Rabbit, Snake"
+
+results: ["Cat, Dog, Snake", "Dog"]
+         ^^^^^^^^^^^^^^^^^  ^^^
+         full match (idx 0)  capture group 1 (idx 1)
+```
+
+Note that only the first occurrence (`Cat, Dog, Snake`) is returned even though
+the input contains a second match (`Cat, Rabbit, Snake`).
+Use `css` or `xpath` if you need all occurrences.
+
 ## Composable
 
 Obviously these recipes are mixable.


### PR DESCRIPTION
## Summary

The `regex` type uses `regexp.FindStringSubmatch` internally and returns only the
**first match** in the input text. This behavior differs from `css` and `xpath`
types, which return all matching nodes — but it was not documented anywhere.

This PR adds a "Behavior notes" subsection under "Regular Expression Scraping" that
explicitly describes:

- **First-match-only**: only the first occurrence is returned regardless of how many
  times the pattern matches in the input.
- **Capture group layout**: `results[0]` is the full match; `results[1+]` are the
  capture groups. The example shows this with a concrete input.
- **Guidance**: use `css` or `xpath` if all occurrences are needed.

## Changes

- `README.md`: added "Behavior notes for `regex` type" subsection with examples

## Verification

- All tests pass (`go test ./...`)
- `go vet ./...`: no findings
- No behavior change — documentation only
