### PR TITLE
fix: cap colspan and rowspan at 100 to prevent OOM from large values

### DIFF
--- a/scraper/recipe_test.go
+++ b/scraper/recipe_test.go
@@ -279,3 +279,38 @@ func TestRegexInvalid(t *testing.T) {
 		t.Errorf("Must be error when invalid regular expression is passed.")
 	}
 }
+
+func TestLargeColspanRowspanIsCapped(t *testing.T) {
+	r := &recipes{{
+		Type:  "table-xpath",
+		Query: "//table",
+		Label: "table1",
+	}}
+	cr, err := r.compile()
+	if err != nil {
+		t.Errorf("Must not be error on this recipe.")
+	}
+	// colspan=10000 and rowspan=10000 would create 10^8 map entries without the cap;
+	// with maxSpan=100 it creates at most 100*100=10000 entries.
+	input := bytes.NewBufferString(`<html><body>
+		<table><tr><td colspan="10000" rowspan="10000">x</td></tr></table>
+	</body></html>`)
+	results, err := cr.extractAll(input)
+	if err != nil {
+		t.Errorf("Must not error on large colspan/rowspan")
+	}
+	if len(results) != 1 {
+		t.Fatalf("Expected 1 result, got %d", len(results))
+	}
+	rows := *results[0].results.TableResult
+	if len(rows) == 0 {
+		t.Errorf("Expected non-empty table result")
+	}
+	// The cell value should be present and capped to maxSpan rows/cols
+	if len(rows) > maxSpan {
+		t.Errorf("rowspan should be capped: got %d rows, expected <= %d", len(rows), maxSpan)
+	}
+	if len(rows[0]) > maxSpan {
+		t.Errorf("colspan should be capped: got %d cols, expected <= %d", len(rows[0]), maxSpan)
+	}
+}

--- a/scraper/table_scraper.go
+++ b/scraper/table_scraper.go
@@ -91,6 +91,21 @@ func mapTableToSliceTable(c map[int]map[int]*string, rowmax int, colmax int) (v 
 	return v
 }
 
+// maxSpan caps colspan and rowspan to prevent OOM from malformed or malicious HTML.
+// colspan=N, rowspan=M causes N*M map entries; uncapped values up to int32 max
+// would exhaust heap. Real tables almost never exceed 100 columns or rows.
+const maxSpan = 100
+
+func clampSpan(v int) int {
+	if v < 1 {
+		return 1
+	}
+	if v > maxSpan {
+		return maxSpan
+	}
+	return v
+}
+
 func parseColspanRowspan(n *html.Node) (int, int) {
 	colspan := 1
 	rowspan := 1
@@ -100,14 +115,14 @@ func parseColspanRowspan(n *html.Node) (int, int) {
 			if err != nil {
 				continue
 			}
-			colspan = int(colspanRead)
+			colspan = clampSpan(int(colspanRead))
 		}
 		if strings.ToLower(attr.Key) == "rowspan" {
 			rowspanRead, err := strconv.ParseInt(attr.Val, 10, 32)
 			if err != nil {
 				continue
 			}
-			rowspan = int(rowspanRead)
+			rowspan = clampSpan(int(rowspanRead))
 		}
 	}
 	return colspan, rowspan


### PR DESCRIPTION
## Summary

`parseColspanRowspan` accepted any value up to `int32` max (2,147,483,647) for
`colspan` and `rowspan` attributes. The inner loop in `editCellInRange` runs
`rowspan × colspan` iterations, so a single cell with `colspan=10000, rowspan=10000`
would generate 10^8 map entries, exhausting heap and causing OOM or a process hang.

This PR adds a `maxSpan = 100` constant and a `clampSpan` helper that caps both
dimensions to `[1, 100]`. Real tables almost never exceed 100 columns or rows, so
legitimate HTML is unaffected.

## Changes

- `scraper/table_scraper.go`: add `maxSpan` constant and `clampSpan` helper; apply
  clamping in `parseColspanRowspan` for both `colspan` and `rowspan`
- `scraper/recipe_test.go`: add `TestLargeColspanRowspanIsCapped` to verify that
  `colspan=10000, rowspan=10000` is capped and does not hang/OOM

## Verification

- `go test ./...`: all tests pass
- `go vet ./...`: no findings
- Coverage: 98.9% (scraper package)

## Trade-offs

A hard cap of 100 may clip unusually wide tables (e.g., spreadsheet exports). The
value is conservative and can be raised if real-world cases surface.