### PR TITLE
Restrict config file access to .json extension only

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -52,10 +52,13 @@ func (s *ServerContext) handler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *ServerContext) confFilePathFromRequest(r *http.Request) string {
+func (s *ServerContext) confFilePathFromRequest(r *http.Request) (string, error) {
 	// To avoid directory traversal
 	resolvedPath := filepath.Join(s.ConfigDirectory, filepath.FromSlash(path.Clean("/"+r.URL.Path)))
-	return resolvedPath
+	if filepath.Ext(resolvedPath) != ".json" {
+		return "", fmt.Errorf("only .json files are accessible")
+	}
+	return resolvedPath, nil
 }
 
 func errorStatus(w http.ResponseWriter, err error) {
@@ -76,7 +79,12 @@ func errorStatus(w http.ResponseWriter, err error) {
 
 func (s *ServerContext) handlerGET(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	confFile, err := os.Open(s.confFilePathFromRequest(r))
+	confPath, err := s.confFilePathFromRequest(r)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	confFile, err := os.Open(confPath)
 	if err != nil {
 		errorStatus(w, err)
 		return
@@ -91,7 +99,12 @@ func (s *ServerContext) handlerGET(w http.ResponseWriter, r *http.Request) {
 
 func (s *ServerContext) handlerPOST(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	confFile, err := os.Open(s.confFilePathFromRequest(r))
+	confPath, err := s.confFilePathFromRequest(r)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	confFile, err := os.Open(confPath)
 	if err != nil {
 		errorStatus(w, err)
 		return
@@ -104,7 +117,11 @@ func (s *ServerContext) handlerPOST(w http.ResponseWriter, r *http.Request) {
 
 func (s *ServerContext) handlerPUT(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	targetPath := s.confFilePathFromRequest(r)
+	targetPath, err := s.confFilePathFromRequest(r)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
 
 	tmpFile, err := os.CreateTemp(filepath.Dir(targetPath), ".put-tmp-*")
 	if err != nil {
@@ -134,7 +151,12 @@ func (s *ServerContext) handlerPUT(w http.ResponseWriter, r *http.Request) {
 
 func (s *ServerContext) handlerDELETE(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	err := os.Remove(s.confFilePathFromRequest(r))
+	confPath, err := s.confFilePathFromRequest(r)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	err = os.Remove(confPath)
 	if err != nil {
 		errorStatus(w, err)
 		return


### PR DESCRIPTION
## Summary

`confFilePathFromRequest` returned a path to any file under `ConfigDirectory`,
regardless of extension. This meant GET, PUT, POST, and DELETE could operate on
non-JSON files in the config directory — outside the intended scope of the API.

This change adds a `.json` extension guard to `confFilePathFromRequest`.
Any request path that does not resolve to a `.json` file is now rejected with
400 Bad Request before the handler proceeds.

## Changes

- `server/server.go`: `confFilePathFromRequest` now returns `(string, error)`;
  returns an error if `filepath.Ext` of the resolved path is not `.json`
- All four handlers (`GET`, `POST`, `PUT`, `DELETE`) check the error and return
  `400 Bad Request` if the path is rejected

## Why not a Content-Type check on PUT?

The extension whitelist is more robust as a boundary guard: it enforces the
file-system contract regardless of the request's Content-Type header, which is
client-controlled and easy to spoof. A Content-Type check alone would still
allow writing to non-JSON paths if the header happened to be correct.

## Trade-offs

- Clients that previously accessed non-`.json` paths (e.g. to inspect raw files)
  will now receive 400. Given that the server is documented as a JSON config
  management API, this is the intended constraint.

## Verification

- `go test ./...` — pass
- `go vet ./...` — pass
