### PR TITLE
ci: update GoReleaser v2 release checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,13 @@ jobs:
 
       - run: go install
 
+      - name: check GoReleaser config
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: check
+
   goreleaser:
     if: github.event_name == 'release' && !github.event.release.prerelease
     runs-on: ubuntu-latest
@@ -54,7 +61,7 @@ jobs:
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
-          version: latest
-          args: release --rm-dist
+          version: "~> v2"
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+version: 2
 before:
   hooks:
     # You may remove this if you don't use go modules.
@@ -14,16 +15,11 @@ builds:
       - windows
       - darwin
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ title .Os }}_{{ if eq .Arch "amd64" }}x86_64{{ else if eq .Arch "386" }}i386{{ else }}{{ .Arch }}{{ end }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
## Summary
- Pin the release workflow to the GoReleaser v2 release line and use the v2 cleanup flag.
- Migrate the GoReleaser config to v2 syntax while preserving the existing archive naming convention.
- Run GoReleaser config checks on pull requests so release config drift is caught before release events.

## Verification
- actionlint .github/workflows/release.yml
- go vet ./...
- go mod tidy && git diff --exit-code -- go.mod go.sum
- go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...
- go install
- go run github.com/goreleaser/goreleaser/v2@v2.16.0 check
- go run github.com/goreleaser/goreleaser/v2@v2.16.0 release --snapshot --clean
- git diff --check

## Notes
- GoReleaser was run through go run because it is not installed locally.
- staticcheck reported one pre-existing SA1019 warning in server/server_test.go that is outside this release configuration change.
