### PR TITLE
fix: add request logging middleware to server

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -4,13 +4,34 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/kitsuyui/scraper/scraper"
 )
+
+type responseRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (rr *responseRecorder) WriteHeader(code int) {
+	rr.status = code
+	rr.ResponseWriter.WriteHeader(code)
+}
+
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rec := &responseRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r)
+		log.Printf("%s %s %d %s", r.Method, r.URL.Path, rec.status, time.Since(start))
+	})
+}
 
 const maxBodyBytes = 10 * 1024 * 1024 // 10 MB
 
@@ -148,7 +169,7 @@ func CreateServer(bindHost string, bindPort int, configDir string) (*http.Server
 		return nil, err
 	}
 	bindAddr := fmt.Sprintf("%s:%d", bindHost, bindPort)
-	handler := http.MaxBytesHandler(http.HandlerFunc(sc.handler), maxBodyBytes)
+	handler := loggingMiddleware(http.MaxBytesHandler(http.HandlerFunc(sc.handler), maxBodyBytes))
 	server := &http.Server{Addr: bindAddr, Handler: handler}
 	return server, nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3,7 +3,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -12,11 +12,40 @@ import (
 	"testing"
 )
 
+func TestLoggingMiddleware(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	server := httptest.NewServer(loggingMiddleware(inner))
+	defer server.Close()
+
+	res, err := http.Get(server.URL + "/test-path")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res.Body.Close()
+
+	got := buf.String()
+	if !strings.Contains(got, "GET") {
+		t.Errorf("log line missing method: %q", got)
+	}
+	if !strings.Contains(got, "/test-path") {
+		t.Errorf("log line missing path: %q", got)
+	}
+	if !strings.Contains(got, "404") {
+		t.Errorf("log line missing status: %q", got)
+	}
+}
+
 var testConfigDir string
 var serverContext ServerContext
 
 func TestMain(m *testing.M) {
-	dir, err := ioutil.TempDir("", "tmp")
+	dir, err := os.MkdirTemp("", "tmp")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -181,7 +210,7 @@ func postRequest(server *httptest.Server, postHTML string, postPath string) (int
 		log.Fatal(err)
 	}
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -201,7 +230,7 @@ func putRequest(server *httptest.Server, postJSON string, postPath string) (int,
 		log.Fatal(err)
 	}
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	return res.StatusCode, string(body), err
 }
 
@@ -211,7 +240,7 @@ func getRequest(server *httptest.Server, getPath string) (int, string, error) {
 		log.Fatal(err)
 	}
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -229,6 +258,6 @@ func deleteRequest(server *httptest.Server, deletePath string) (int, string, err
 		log.Fatal(err)
 	}
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	return res.StatusCode, string(body), err
 }


### PR DESCRIPTION
## Summary

Add a `loggingMiddleware` to the HTTP server so every request is logged with method, path, status code, and elapsed time via stdlib `log`. Previously the server produced no access log, making it impossible to observe which paths were called, what status codes were returned, or how long requests took.

### Changes

**server/server.go**
- Add `responseRecorder` type that wraps `http.ResponseWriter` to capture the written status code.
- Add `loggingMiddleware(next http.Handler) http.Handler` that records one log line per request: `<METHOD> <PATH> <STATUS> <DURATION>`.
- Wrap the handler chain in `CreateServer` with `loggingMiddleware`.

**server/server_test.go**
- Add `TestLoggingMiddleware` that verifies a log line containing method, path, and status code is emitted for each request.
- Replace deprecated `io/ioutil` calls with `io.ReadAll` / `os.MkdirTemp` (Go 1.19+ equivalents).

## Verification

```
go test ./...
staticcheck ./...
```

All tests pass. `staticcheck` clean.

## Trade-offs

- Logging uses stdlib `log` (goes to stderr). Structured/JSON logging would require an external dependency not currently used elsewhere in the project.
- `responseRecorder.WriteHeader` only intercepts explicit `WriteHeader` calls; responses that write the body without calling `WriteHeader` are recorded as 200 (the default), which is correct Go behaviour.
