### PR TITLE
fix: close config file handle in scraping mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,11 +102,13 @@ func main() {
 		}
 
 		configFilepath, _ := opts.String("--config")
-		confFile, err := os.Open(configFilepath)
+		cf, err := os.Open(configFilepath)
 		if err != nil {
 			reportError(err, exitConfigFile)
 			return
 		}
+		defer cf.Close()
+		confFile = cf
 
 		err = scraper.ScrapeByConfFile(confFile, input, output)
 		if err != nil {


### PR DESCRIPTION
## Summary

The scraping mode (`scraper [-c <conf>]`) opened the config file with `os.Open` but never called `Close`, unlike validate mode which has `defer c.Close()`. This adds `defer cf.Close()` to make the two code paths consistent.

## Change

- Introduce a separate `*os.File` variable (`cf`) for the config file so `defer cf.Close()` can be called before assigning to the `io.Reader` interface variable (`confFile`).
- This follows the same pattern already used for the input file (`inputFile` / `defer inputFile.Close()`).

## Why

While this CLI exits quickly and the OS reclaims file descriptors on exit, the explicit `Close` is important for:
1. **Consistency**: validate mode already calls `defer c.Close()`; scraping mode should match.
2. **Safety for future reuse**: if this pattern is copied into a longer-lived process or goroutine, the missing close would become a real file descriptor leak.

## Verification

```
go vet ./...
go test ./...
```

All existing tests pass.
