### PR TITLE
fix: write output to temp file and rename to prevent truncation on error

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/docopt/docopt-go"
 	"github.com/kitsuyui/scraper/scraper"
@@ -77,10 +78,8 @@ func main() {
 	} else {
 		var confFile io.Reader
 		var input io.Reader
-		var output io.Writer
 
 		input = os.Stdin
-		output = standardOutput
 		if inputFilepath, err := opts.String("--input"); err == nil {
 			inputFile, err := os.Open(inputFilepath)
 			if err != nil {
@@ -91,16 +90,6 @@ func main() {
 			input = inputFile
 		}
 
-		if outputFilepath, err := opts.String("--output"); err == nil {
-			outputFile, err := os.Create(outputFilepath)
-			if err != nil {
-				reportError(err, exitOutputFile)
-				return
-			}
-			defer outputFile.Close()
-			output = outputFile
-		}
-
 		configFilepath, _ := opts.String("--config")
 		confFile, err := os.Open(configFilepath)
 		if err != nil {
@@ -108,7 +97,31 @@ func main() {
 			return
 		}
 
-		err = scraper.ScrapeByConfFile(confFile, input, output)
+		if outputFilepath, err := opts.String("--output"); err == nil {
+			// Write to a temp file in the same directory, then rename on success.
+			// This prevents an existing output file from being truncated when
+			// scraping fails partway through.
+			tmpFile, err := os.CreateTemp(filepath.Dir(outputFilepath), ".scraper-output-*")
+			if err != nil {
+				reportError(err, exitOutputFile)
+				return
+			}
+			scrapeErr := scraper.ScrapeByConfFile(confFile, input, tmpFile)
+			tmpFile.Close()
+			if scrapeErr != nil {
+				os.Remove(tmpFile.Name())
+				reportError(scrapeErr, exitScrape)
+				return
+			}
+			if err := os.Rename(tmpFile.Name(), outputFilepath); err != nil {
+				os.Remove(tmpFile.Name())
+				reportError(err, exitOutputFile)
+				return
+			}
+			return
+		}
+
+		err = scraper.ScrapeByConfFile(confFile, input, standardOutput)
 		if err != nil {
 			reportError(err, exitScrape)
 			return

--- a/main_test.go
+++ b/main_test.go
@@ -274,6 +274,38 @@ func TestCLIErrorPathsUseDistinctExitCodes(t *testing.T) {
 	}
 }
 
+func TestOutputFilePreservedOnScrapeError(t *testing.T) {
+	dir := t.TempDir()
+	outputFilepath := filepath.Join(dir, "output.json")
+
+	// Write initial content to the output file.
+	initial := []byte(`{"previous": "content"}`)
+	if err := os.WriteFile(outputFilepath, initial, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Trigger a scrape error by feeding a directory as the HTML input.
+	result := runCLI(t, []string{
+		"scraper",
+		"-c", "test_assets/config.json",
+		"-i", "/",
+		"-o", outputFilepath,
+	}, nil)
+
+	if !result.exited || result.exitCode != exitScrape {
+		t.Fatalf("expected exit with code %d, got exited=%v code=%d", exitScrape, result.exited, result.exitCode)
+	}
+
+	// The original file must not have been truncated.
+	got, err := os.ReadFile(outputFilepath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(initial) {
+		t.Errorf("output file was modified on scrape error: got %q, want %q", got, initial)
+	}
+}
+
 func TestMainCommand(t *testing.T) {
 	opts, err := docopt.ParseArgs(usage, []string{}, "")
 	if err != nil {


### PR DESCRIPTION
## Summary

When `-o` is specified, the previous code called `os.Create` immediately,
truncating any existing output file before scraping began. If scraping
then failed (invalid config, parse error, network issue, etc.) the
caller's output file was left empty — the previous valid content was
gone.

## Changes

**`main.go`**

Replace `os.Create(outputFilepath)` with `os.CreateTemp` in the same
directory, and `os.Rename` the temp file to the target on success. On
any failure after the temp file is created, `os.Remove` cleans it up.
The original output file is never touched until scraping has fully
succeeded.

`filepath.Dir` is used so the temp file lives on the same filesystem as
the target, keeping `os.Rename` atomic (single filesystem rename
syscall, no cross-device copy).

**`main_test.go`**

Add `TestOutputFilePreservedOnScrapeError`: writes known content to the
output path, triggers a scrape error (directory fed as HTML input),
and asserts the file was not modified.

## Verification

```
gofmt -w .
go vet ./...
go mod tidy
go test -v -race ./...
```

All checks pass locally.
