### PR TITLE
docs: make compiledRecipe and extractResult XOR invariants explicit

### DIFF
--- a/scraper/recipe.go
+++ b/scraper/recipe.go
@@ -52,6 +52,10 @@ func (sr *scrapeResult) MarshalJSON() ([]byte, error) {
 
 type recipes []recipe
 
+// compiledRecipe holds a compiled recipe ready for extraction.
+// Invariant: exactly one of domScraper and textScraper is non-nil.
+// This invariant is established by compile() and must be preserved by any
+// future constructors. extractAll panics if both are nil.
 type compiledRecipe struct {
 	domScraper  domScraper
 	textScraper textScraper
@@ -68,6 +72,9 @@ type domScraper interface {
 	extractFromNode(*html.Node) *extractResult
 }
 
+// extractResult holds the output of a single scraper execution.
+// Invariant: exactly one of PlainResult and TableResult is non-nil.
+// TableResult is set by table-* scrapers; PlainResult by all others.
 type extractResult struct {
 	PlainResult *[]string
 	TableResult *[][][]string
@@ -161,6 +168,11 @@ func (crs compiledRecipes) extractAll(input io.Reader) ([]scrapeResult, error) {
 		} else if cr.domScraper != nil {
 			er := &scrapeResult{recipe: cr.recipe, results: cr.domScraper.extractFromNode(doc)}
 			ers = append(ers, *er)
+		} else {
+			// Both scrapers nil: this violates the compiledRecipe invariant.
+			// compile() always sets exactly one; reaching here means a future
+			// constructor broke the invariant, and silent skipping would hide it.
+			panic(fmt.Sprintf("compiledRecipe invariant violation: both domScraper and textScraper are nil for recipe type %q", cr.recipe.Type))
 		}
 	}
 	return ers, nil


### PR DESCRIPTION
## Summary

The recipe pipeline has three implicit state-machine invariants that were
not documented and one that was actively hidden by a silent skip:

- **`compiledRecipe`**: exactly one of `domScraper` and `textScraper` is
  non-nil. `compile()` enforces this, but the type allows both-nil or
  both-non-nil states, and no comment explained the constraint.
- **`extractResult`**: exactly one of `PlainResult` and `TableResult` is
  non-nil. Table scrapers set `TableResult`; all others set `PlainResult`.
  Again, the type is unconstrained and the invariant was implicit.
- **`extractAll` silent skip**: when both scrapers on a `compiledRecipe`
  are nil (should be unreachable given current `compile()` logic), the
  loop body silently dropped the recipe with no signal. A future
  constructor that breaks the invariant would cause results to vanish
  without any diagnostic.

## Changes

- Add comments to `compiledRecipe` and `extractResult` documenting the
  XOR invariants so future implementors know they must uphold them.
- Replace the implicit fall-through in `extractAll` with an explicit
  `else` branch that panics with a descriptive message. This turns a
  silent invariant violation into an immediate, identifiable failure.

## Test plan

- All existing tests pass: `go test -race ./...`
- `go vet ./...` — no new warnings
- The panic branch is not reachable via `compile()`; the change converts
  a silent-skip dead-code path into a loud assertion for future callers.
