### PR TITLE
fix: complete htmlquery migration by removing xquery dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/andybalholm/cascadia v1.3.3
 	github.com/antchfx/htmlquery v1.3.5
 	github.com/antchfx/xpath v1.3.6
-	github.com/antchfx/xquery v0.0.0-20180515051857-ad5b8c7a47b0
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	golang.org/x/net v0.50.0
 )

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/antchfx/htmlquery v1.3.5/go.mod h1:5oyIPIa3ovYGtLqMPNjBF2Uf25NPCKsMjC
 github.com/antchfx/xpath v1.3.5/go.mod h1:i54GszH55fYfBmoZXapTHN8T8tkcHfRgLyVwwqzXNcs=
 github.com/antchfx/xpath v1.3.6 h1:s0y+ElRRtTQdfHP609qFu0+c6bglDv20pqOViQjjdPI=
 github.com/antchfx/xpath v1.3.6/go.mod h1:i54GszH55fYfBmoZXapTHN8T8tkcHfRgLyVwwqzXNcs=
-github.com/antchfx/xquery v0.0.0-20180515051857-ad5b8c7a47b0 h1:JaCC8jz0zdMLk2m+qCCVLLLM/PL93p84w4pK3aJWj60=
-github.com/antchfx/xquery v0.0.0-20180515051857-ad5b8c7a47b0/go.mod h1:LzD22aAzDP8/dyiCKFp31He4m2GPjl0AFyzDtZzUu9M=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815 h1:bWDMxwH3px2JBh6AyO7hdCn/PkvCZXii8TGj7sbtEbQ=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/scraper/recipe.go
+++ b/scraper/recipe.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"strings"
 
-	htmlquery "github.com/antchfx/xquery/html"
+	htmlquery "github.com/antchfx/htmlquery"
 	"golang.org/x/net/html"
 )
 

--- a/scraper/xpath_scraper.go
+++ b/scraper/xpath_scraper.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	"github.com/antchfx/xpath"
-	htmlquery "github.com/antchfx/xquery/html"
+	htmlquery "github.com/antchfx/htmlquery"
 	"golang.org/x/net/html"
 )
 


### PR DESCRIPTION
## Problem

`recipe.go` and `xpath_scraper.go` imported `github.com/antchfx/xquery/html`,
a package that has not been updated since 2018 and was superseded by
`github.com/antchfx/htmlquery` (and related packages). `table_scraper.go`
already used the successor package, leaving two packages in `go.mod` for
the same HTML/XPath query API.

## Change

- `scraper/recipe.go`: update import alias to `github.com/antchfx/htmlquery`
- `scraper/xpath_scraper.go`: update import alias to `github.com/antchfx/htmlquery`
- `go.mod` / `go.sum`: remove `github.com/antchfx/xquery` (via `go mod tidy`)

The public API (`Parse`, `Find`, `CreateXPathNavigator`) is identical across
both packages, so no call-site changes are required.

## Verification

- `go build ./...` passes
- `go test ./...` passes (all three packages: scraper root, scraper/scraper, scraper/server)
- `staticcheck ./...` shows one pre-existing `io/ioutil` deprecation in
  `server/server_test.go`; no new findings from this change

## Trade-offs

- **Compatibility**: No behavior change — the successor package provides the
  same functions with the same signatures.
- **Maintenance**: Reduces `go.mod` from two HTML/XPath packages to one,
  making future dependency updates simpler.
