### PR TITLE
ci: add coverage and code-to-test ratio thresholds to octocov

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,11 +2,13 @@
 coverage:
   paths:
     - coverage.out
+  acceptable: 80%
 codeToTestRatio:
   code:
     - "**/*.go"
   test:
     - "**/*_test.go"
+  acceptable: "1:0.5"
 testExecutionTime:
   if: true
 diff:


### PR DESCRIPTION
## Summary

- Add `coverage.acceptable: 80%` to `.octocov.yml` to gate PRs when coverage drops below 80%.
- Add `codeToTestRatio.acceptable: "1:0.5"` to enforce a minimum code-to-test ratio.

## Motivation

The `.octocov.yml` measured coverage and code-to-test ratio but had no `acceptable` thresholds, so a PR reducing coverage by any amount would still pass CI. Current baseline is 90.5% coverage and 1:0.6 code-to-test ratio; the thresholds (80% / 1:0.5) provide a safety floor without blocking current development.

## Verification

- Confirmed current coverage (90.5%) and code-to-test ratio (1:0.6) from recent CI run on main.
- Thresholds set conservatively below current values to avoid immediate CI breakage.
- YAML syntax validated.
