### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,21 @@ $ ./bin/build.sh
 $ docker run --rm -v "$(pwd)":/root -w /root tcnksm/gox sh -c "./bin/build.sh"
 ```
 
+## Development
+
+Install [lefthook](https://github.com/evilmartians/lefthook) and run the following command to set up the Git hooks:
+
+```console
+$ lefthook install
+```
+
+### Git hooks
+
+- **pre-commit**: runs `go vet ./...` to catch issues before each commit.
+- **pre-push**: runs `go vet ./...` and `go test ./...` before each push.
+
+The CI pipeline still runs the full test suite on every pull request and push to main — the hooks bring the same feedback earlier, during local development.
+
 ## LICENSE
 
 ### Source

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: vet
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; go vet ./...
+
+pre-push:
+  jobs:
+    - name: vet
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; go vet ./...
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; go test ./...


### PR DESCRIPTION
## Summary

- Add `lefthook.yml` with a `pre-commit` hook that runs `go vet ./...` and a `pre-push` hook that runs `go vet ./...` and `go test ./...`.
- Add a `## Development` section to `README.md` documenting `lefthook install` and the hook behaviour.
- The CI workflow (`golang-test.yml`) is unchanged; the hooks mirror its checks locally to surface failures earlier.

## Test plan

- [ ] `go vet ./...` passes on current code (verified locally).
- [ ] `go test ./...` passes on current code (verified locally).
- [ ] Pre-commit hook fired and passed during the commit.
- [ ] Pre-push hook fired and passed (`vet` + `test`) during `git push`.
- [ ] Only `lefthook.yml` and `README.md` are changed; no CI or Go source files touched.
